### PR TITLE
Update instructions to run release binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,5 @@ cargo bench
 _WIP_: Installer coming soon
 
 ```
-cargo build --release
-cargo run my_program.est
+cargo run --release my_program.est
 ```


### PR DESCRIPTION
The previous instructions built the release binary but then used the debug build.